### PR TITLE
docs: the license link didn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Built using [a-frame-in-100-lines](https://github.com/Zizzamia/a-frame-in-100-li
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details


### PR DESCRIPTION
The previous link did not work